### PR TITLE
Nonce values generated by new version of Canvas cannot be stored.

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -128,7 +128,7 @@
     if ($ok && !table_exists($db, $prefix . DataConnector\DataConnector::NONCE_TABLE_NAME)) {
       $sql = "CREATE TABLE {$prefix}" . DataConnector\DataConnector::NONCE_TABLE_NAME . ' (' .
              'consumer_pk int(11) NOT NULL, ' .
-             'value varchar(32) NOT NULL, ' .
+             'value varchar(64) NOT NULL, ' .
              'expires datetime NOT NULL, ' .
              'PRIMARY KEY (consumer_pk, value))';
       $ok = $db->exec($sql) !== FALSE;


### PR DESCRIPTION
The new version of Canvas always creates nonce values that are more than 32 characters long, as a result the nonce values do not get stored in the database which in turn causes theLTI launch to fail. Allocating 64 characters for the nonce value resolves this issue.